### PR TITLE
Fix #6: Changing direct access to calling getter method

### DIFF
--- a/src/JeremyKendall/Slim/Auth/Middleware/Authorization.php
+++ b/src/JeremyKendall/Slim/Auth/Middleware/Authorization.php
@@ -66,8 +66,8 @@ class Authorization extends \Slim\Middleware
         $role = $this->getRole($auth->getIdentity());
 
         $isAuthorized = function () use ($app, $auth, $acl, $role) {
-            $resource = $app->router->getCurrentRoute()->getPattern();
-            $privilege = $app->request->getMethod();
+            $resource = $app->router()->getCurrentRoute()->getPattern();
+            $privilege = $app->request()->getMethod();
             $hasIdentity = $auth->hasIdentity();
             $isAllowed = $acl->isAllowed($role, $resource, $privilege);
 


### PR DESCRIPTION
In current version of Slim Framework, both $app->router and $app->request are protected.

To fix it, now it calls getter methods $app->router() and $app->request()
