### PR TITLE
Fix composer update issue

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,7 @@
     "require-dev": {
         "league/phpunit-coverage-listener": "~1.1",
         "phpunit/phpunit": "4.*",
-        "slim/slim": "^2.4.2"
+        "slim/slim": "2.4.2"
     },
     "autoload": {
         "psr-0": {


### PR DESCRIPTION
The version string is invalid which makes composer update break with:

[RuntimeException]                                                                                                                                                             
Could not load package jeremykendall/slim-auth in http://packagist.org: [UnexpectedValueException] Could not parse version constraint ^2.4.2: Invalid version string "^2.4.2"