### PR TITLE
0.0.7 alpha

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -3,13 +3,15 @@
 require_once './vendor/autoload.php';
 
 $finder = \Symfony\CS\Finder\DefaultFinder::create()
-    ->in('src/');
+    ->in('bin/')
+    ->in('src/')
+    ->in('tests/');
 
 return \Symfony\CS\Config\Config::create()
     ->setUsingCache(true)
     ->fixers([
-        '-concat_without_spaces', 
-        'concat_with_spaces', 
+        '-concat_without_spaces',
+        'concat_with_spaces',
         'ordered_use',
     ])
     ->finder($finder);

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ php:
   - 5.4
   - 5.5
   - 5.6
-  - '7'
 
 before_script:
   - composer self-update

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ php:
   - 5.4
   - 5.5
   - 5.6
+  - '7'
 
 before_script:
   - composer self-update

--- a/composer.json
+++ b/composer.json
@@ -38,7 +38,8 @@
     "require-dev": {
         "league/phpunit-coverage-listener": "~1.1",
         "phpunit/phpunit": "4.*",
-        "slim/slim": "^2.4.2"
+        "slim/slim": "^2.4.2",
+        "jeremykendall/debug-die": "0.0.1.*"
     },
     "autoload": {
         "psr-0": {

--- a/composer.json
+++ b/composer.json
@@ -29,8 +29,8 @@
     ],
     "require": {
         "php": ">=5.3.7",
-        "jeremykendall/password-validator": "2.*",
-        "wp-cli/php-cli-tools": "~0.9",
+        "jeremykendall/password-validator": "3.*",
+        "wp-cli/php-cli-tools": "~0.10",
         "zendframework/zend-authentication": "~2",
         "zendframework/zend-permissions-acl": "~2",
         "zendframework/zend-session": "~2"

--- a/composer.json
+++ b/composer.json
@@ -31,9 +31,9 @@
         "php": ">=5.3.7",
         "jeremykendall/password-validator": "3.*",
         "wp-cli/php-cli-tools": "~0.10",
-        "zendframework/zend-authentication": "~2",
-        "zendframework/zend-permissions-acl": "~2",
-        "zendframework/zend-session": "~2"
+        "zendframework/zend-authentication": "2.*",
+        "zendframework/zend-permissions-acl": "2.*",
+        "zendframework/zend-session": "2.*"
     },
     "require-dev": {
         "league/phpunit-coverage-listener": "~1.1",

--- a/src/JeremyKendall/Slim/Auth/Bootstrap.php
+++ b/src/JeremyKendall/Slim/Auth/Bootstrap.php
@@ -15,6 +15,7 @@ use JeremyKendall\Slim\Auth\Middleware\Authorization as AuthorizationMiddleware;
 use Slim\Slim;
 use Zend\Authentication\Adapter\AbstractAdapter;
 use Zend\Authentication\AuthenticationService;
+use Zend\Authentication\Storage\Session as SessionStorage;
 use Zend\Authentication\Storage\StorageInterface;
 use Zend\Permissions\Acl\AclInterface;
 
@@ -101,10 +102,16 @@ class Bootstrap
     /**
      * Gets storage.
      *
+     * Returns instance of Zend\Authentication\Storage\Session if storage is null
+     *
      * @return StorageInterface AuthenticationService storage
      */
     public function getStorage()
     {
+        if (is_null($this->storage)) {
+            $this->storage = new SessionStorage('slim_auth');
+        }
+
         return $this->storage;
     }
 

--- a/src/JeremyKendall/Slim/Auth/Exception/AuthException.php
+++ b/src/JeremyKendall/Slim/Auth/Exception/AuthException.php
@@ -9,7 +9,7 @@
  * @license   http://github.com/jeremykendall/slim-auth/blob/master/LICENSE MIT
  */
 
-namespace JeremyKendall\Slim\Auth;
+namespace JeremyKendall\Slim\Auth\Exception;
 
 /**
  * Slim Auth Exception.

--- a/src/JeremyKendall/Slim/Auth/Exception/HttpUnauthorizedException.php
+++ b/src/JeremyKendall/Slim/Auth/Exception/HttpUnauthorizedException.php
@@ -12,17 +12,17 @@
 namespace JeremyKendall\Slim\Auth\Exception;
 
 /**
- * HTTP 403 Exception.
+ * HTTP 401 Exception.
  */
-class HttpForbiddenException extends AuthException
+class HttpUnauthorizedException extends AuthException
 {
     /**
      * Public constructor.
      */
     public function __construct()
     {
-        $message = 'You are not authorized to access this resource';
-        $code = 403;
+        $message = 'You must authenticate to access this resource.';
+        $code = 401;
 
         parent::__construct($message, $code);
     }

--- a/src/JeremyKendall/Slim/Auth/Middleware/Authorization.php
+++ b/src/JeremyKendall/Slim/Auth/Middleware/Authorization.php
@@ -12,6 +12,7 @@
 namespace JeremyKendall\Slim\Auth\Middleware;
 
 use JeremyKendall\Slim\Auth\Exception\HttpForbiddenException;
+use JeremyKendall\Slim\Auth\Exception\HttpUnauthorizedException;
 use Zend\Authentication\AuthenticationServiceInterface;
 use Zend\Permissions\Acl\AclInterface;
 
@@ -57,7 +58,8 @@ class Authorization extends \Slim\Middleware
      * Uses hook to check for user authorization.
      * Will redirect to named login route if user is unauthorized.
      *
-     * @throws \RuntimeException if there isn't a named 'login' route
+     * @throws HttpForbiddenException    If an authenticated user is not authorized for the resource
+     * @throws HttpUnauthorizedException If an unauthenticated user is not authorized for the resource
      */
     public function call()
     {
@@ -77,7 +79,7 @@ class Authorization extends \Slim\Middleware
             }
 
             if (!$hasIdentity && !$isAllowed) {
-                return $app->redirect($app->urlFor('login'));
+                throw new HttpUnauthorizedException();
             }
         };
 

--- a/tests/JeremyKendall/Slim/Auth/Tests/Adapter/Db/PdoAdapterTest.php
+++ b/tests/JeremyKendall/Slim/Auth/Tests/Adapter/Db/PdoAdapterTest.php
@@ -63,8 +63,8 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         $this->passwordValidator->expects($this->once())
             ->method('isValid')
             ->with(
-                $this->plainTextPassword, 
-                $this->identity['hashed_password'], 
+                $this->plainTextPassword,
+                $this->identity['hashed_password'],
                 $this->identity['id']
             )
             ->will($this->returnValue(new ValidationResult(ValidationResult::SUCCESS)));
@@ -89,7 +89,7 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ->method('isValid')
             ->with(
                 'bad password',
-                $this->identity['hashed_password'], 
+                $this->identity['hashed_password'],
                 $this->identity['id']
             )
             ->will($this->returnValue(
@@ -128,8 +128,8 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
         $this->passwordValidator->expects($this->once())
             ->method('isValid')
             ->with(
-                $this->plainTextPassword, 
-                $this->identity['hashed_password'], 
+                $this->plainTextPassword,
+                $this->identity['hashed_password'],
                 $this->identity['id']
             )
             ->will($this->returnValue(new ValidationResult(ValidationResult::SUCCESS)));
@@ -178,11 +178,11 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
 
     private function setUpAdapter()
     {
-        $this->passwordValidator = 
+        $this->passwordValidator =
             $this->getMock('JeremyKendall\Password\PasswordValidatorInterface');
 
         $this->adapter = new PdoAdapter(
-            $this->db, 
+            $this->db,
             $tableName = 'application_users',
             $identityColumn = 'email_address',
             $credentialColumn = 'hashed_password',

--- a/tests/JeremyKendall/Slim/Auth/Tests/BootstrapFunctionalTest.php
+++ b/tests/JeremyKendall/Slim/Auth/Tests/BootstrapFunctionalTest.php
@@ -18,7 +18,7 @@ class BootstrapFunctionalTest extends \PHPUnit_Framework_TestCase
 
     /**
      * Confirms that $this->app->auth and $this->app->authenticator
-     * return the expected class instances
+     * return the expected class instances.
      */
     public function testBootstrap()
     {
@@ -33,7 +33,7 @@ class BootstrapFunctionalTest extends \PHPUnit_Framework_TestCase
 
         $this->assertInstanceOf(
             'JeremyKendall\Slim\Auth\Authenticator',
-            $app->authenticator 
+            $app->authenticator
         );
     }
 }

--- a/tests/JeremyKendall/Slim/Auth/Tests/BootstrapTest.php
+++ b/tests/JeremyKendall/Slim/Auth/Tests/BootstrapTest.php
@@ -4,7 +4,6 @@ namespace JeremyKendall\Slim\Auth\Tests;
 
 use JeremyKendall\Slim\Auth\Bootstrap;
 use Slim\Slim;
-use Zend\Authentication\AuthenticationService;
 use Zend\Authentication\Storage\StorageInterface;
 use Zend\Permissions\Acl\Acl;
 
@@ -56,10 +55,17 @@ class BootstrapTest extends \PHPUnit_Framework_TestCase
 
     public function testGetSetStorage()
     {
-        $storage = $this->getMock('Zend\Authentication\Storage\StorageInterface');
+        $defaultStorage = $this->bootstrap->getStorage();
 
-        $this->assertNull($this->bootstrap->getStorage());
+        $this->assertInstanceOf(
+            'Zend\Authentication\Storage\StorageInterface',
+            $defaultStorage
+        );
+        $this->assertEquals('slim_auth', $defaultStorage->getNamespace());
+
+        $storage = $this->getMock('Zend\Authentication\Storage\StorageInterface');
         $this->bootstrap->setStorage($storage);
+
         $this->assertSame($storage, $this->bootstrap->getStorage());
     }
 

--- a/tests/JeremyKendall/Slim/Auth/Tests/Middleware/AuthorizationTest.php
+++ b/tests/JeremyKendall/Slim/Auth/Tests/Middleware/AuthorizationTest.php
@@ -2,6 +2,7 @@
 
 namespace JeremyKendall\Slim\Auth\Tests\Middleware;
 
+use JeremyKendall\Slim\Auth\Exception\AuthException;
 use JeremyKendall\Slim\Auth\Middleware\Authorization;
 use Zend\Permissions\Acl\Acl;
 use Zend\Permissions\Acl\Role\GenericRole as Role;
@@ -43,13 +44,12 @@ class AuthorizationTest extends \PHPUnit_Framework_TestCase
      */
     public function testRouteAuthentication(
         $requestMethod,
-        $path, 
+        $path,
         $location,
         $hasIdentity,
         $identity,
         $httpStatus
-    )
-    {
+    ) {
         \Slim\Environment::mock(array(
             'REQUEST_METHOD' => $requestMethod,
             'PATH_INFO' => $path,
@@ -65,9 +65,9 @@ class AuthorizationTest extends \PHPUnit_Framework_TestCase
 
         $app = new \Slim\Slim(array('debug' => false));
 
-        $app->error(function(\Exception $e) use ($app) {
-            // Example of handling 403 FORBIDDEN
-            if ($e instanceof \JeremyKendall\Slim\Auth\Exception\HttpForbiddenException) {
+        $app->error(function (\Exception $e) use ($app) {
+            // Example of handling Auth Exceptions
+            if ($e instanceof AuthException) {
                 $app->response->setStatus($e->getCode());
                 $app->response->setBody($e->getMessage());
             }
@@ -90,9 +90,9 @@ class AuthorizationTest extends \PHPUnit_Framework_TestCase
 
     public function authenticationDataProvider()
     {
-        /**
+        /*
         $requestMethod,
-        $path, 
+        $path,
         $location,
         $hasIdentity,
         $identity,
@@ -103,7 +103,7 @@ class AuthorizationTest extends \PHPUnit_Framework_TestCase
             array('GET', '/', null, false, null, 200),
             array('GET', '/login', null, false, null, 200),
             array('POST', '/login', null, false, null, 200),
-            array('GET', '/member', '/login', false, null, 302),
+            array('GET', '/member', null, false, null, 401),
             // Member
             array('GET', '/admin', null, true, new Identity('member'), 403),
             array('DELETE', '/member/photo/992892', null, true, array('role' => 'member'), 200),

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -9,12 +9,3 @@ $loader = require dirname(__DIR__) . '/vendor/autoload.php';
 $loader->add('JeremyKendall\\Slim\\Auth\\Tests\\', __DIR__);
 
 define('SLIM_MODE', 'testing');
-
-function d($var) {
-    var_dump($var);
-}
-
-function dd($var) {
-    d($var);
-    die();
-}


### PR DESCRIPTION
**Changes**
* Adds PHP 7 to `.travis.yml`
* `Bootstrap` now sets `Zend\Authentication\Storage\Session` as default storage

**BC Breaking Changes**
* 302 redirect to named `login` route now throws `HttpUnauthorizedException`. Fixes #11.
* Password Validator upgraded to `3.*`
    * Includes BC breaking change from `3.0.0`
    * Details available [here](https://github.com/jeremykendall/password-validator/releases/tag/3.0.0)
    * Change should have no effect on Slim Auth implementation.