### PR TITLE
Fix pdo identity

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 build
 composer.lock
+vendor/

--- a/src/JeremyKendall/Slim/Auth/Adapter/Db/PdoAdapter.php
+++ b/src/JeremyKendall/Slim/Auth/Adapter/Db/PdoAdapter.php
@@ -87,7 +87,7 @@ class PdoAdapter extends AbstractAdapter
         }
 
         $validationResult = $this->passwordValidator->isValid(
-            $this->credential, $user[$this->credentialColumn], $user['id']
+            $this->credential, $user[$this->credentialColumn], $user[$this->identityColumn]
         );
 
         if ($validationResult->isValid()) {

--- a/tests/JeremyKendall/Slim/Auth/Tests/Adapter/Db/PdoAdapterTest.php
+++ b/tests/JeremyKendall/Slim/Auth/Tests/Adapter/Db/PdoAdapterTest.php
@@ -65,7 +65,7 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->plainTextPassword,
                 $this->identity['hashed_password'],
-                $this->identity['id']
+                $this->identity['email_address']
             )
             ->will($this->returnValue(new ValidationResult(ValidationResult::SUCCESS)));
 
@@ -90,7 +90,7 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ->with(
                 'bad password',
                 $this->identity['hashed_password'],
-                $this->identity['id']
+                $this->identity['email_address']
             )
             ->will($this->returnValue(
                 new ValidationResult(ValidationResult::FAILURE_PASSWORD_INVALID)
@@ -130,7 +130,7 @@ class PdoAdapterTest extends \PHPUnit_Framework_TestCase
             ->with(
                 $this->plainTextPassword,
                 $this->identity['hashed_password'],
-                $this->identity['id']
+                $this->identity['email_address']
             )
             ->will($this->returnValue(new ValidationResult(ValidationResult::SUCCESS)));
 


### PR DESCRIPTION
after investigating the issues in pull request #31 i realized that my way of thinking was not wrong. looking at the tests i realized that the wrong identity is given in the third attribute of the `isValid()` method. in the `setUpAdapter()` function in the unit test there is the email address specified as identityColumn. in the actual test the third attribute used to be the id column and not like it is now the mail address. the tests used to work before because the id attribute in the actual library file was also using `:id`.
