### PR TITLE
Slim 3.x

### DIFF
--- a/src/Adapter/Db/PdoAdapter.php
+++ b/src/Adapter/Db/PdoAdapter.php
@@ -41,6 +41,11 @@ class PdoAdapter extends AbstractAdapter
     private $credentialColumn;
 
     /**
+     * @var string column to be used as the role
+     */
+    private $roleColumn;
+
+    /**
      * @var PasswordValidatorInterface Handles password validation
      */
     protected $passwordValidator;
@@ -59,12 +64,14 @@ class PdoAdapter extends AbstractAdapter
         $tableName,
         $identityColumn,
         $credentialColumn,
+        $roleColumn,
         PasswordValidatorInterface $passwordValidator
     ) {
         $this->db = $db;
         $this->tableName = $tableName;
         $this->identityColumn = $identityColumn;
         $this->credentialColumn = $credentialColumn;
+        $this->roleColumn = $roleColumn;
         $this->passwordValidator = $passwordValidator;
     }
 
@@ -92,7 +99,11 @@ class PdoAdapter extends AbstractAdapter
         if ($validationResult->isValid()) {
             // Don't store password in identity
             unset($user[$this->getCredentialColumn()]);
-
+            // Copy role column into role if set differently
+            if ($this->getRoleColumn() != 'role') {
+              $user['role'] = $user[$this->getRoleColumn()];
+              unset($user[$this->getRoleColumn()]);
+            }
             return new AuthenticationResult(AuthenticationResult::SUCCESS, $user, array());
         }
 

--- a/src/Adapter/Db/PdoAdapter.php
+++ b/src/Adapter/Db/PdoAdapter.php
@@ -163,4 +163,15 @@ class PdoAdapter extends AbstractAdapter
     {
         return $this->credentialColumn;
     }
+    
+    /**
+     * Get getRoleColumn.
+     *
+     * @return string getRoleColumn
+     */
+    public function getRoleColumn()
+    {
+        return $this->roleColumn;
+    }
+    
 }


### PR DESCRIPTION
Hi –

I've added the parameter `$roleColumn` to the constructor of the PdoAdapter Class. Like this you can use a different role column than just "role". In my case, the users table is storing to role in field called usertype.
The `authenticate()` function is just copying the array value of your custom role field into 'role' - that makes it compatible with depending functions.

Best
Urs
